### PR TITLE
adds new_lic_code support to part1

### DIFF
--- a/part1/lib/cart.c
+++ b/part1/lib/cart.c
@@ -47,7 +47,139 @@ static const char *ROM_TYPES[] = {
     "MBC7+SENSOR+RUMBLE+RAM+BATTERY",
 };
 
+char *get_new_lic_code() {
+  // ASCII 00 => 0x3030, 01 => 0X3031, ...etc
+  switch (ctx.header->new_lic_code) {
+  case (0x3030):
+    return "None";
+  case (0x3031):
+    return "Nintendo R&D1";
+  case (0x3038):
+    return "Capcom";
+  case (0x3133):
+    return "Electronic Arts";
+  case (0x3138):
+    return "Hudson Soft";
+  case (0x3139):
+    return "b-ai";
+  case (0x3230):
+    return "kss";
+  case (0x3232):
+    return "pow";
+  case (0x3234):
+    return "PCM Complete";
+  case (0x3235):
+    return "san-x";
+  case (0x3238):
+    return "Kemco Japan";
+  case (0x3239):
+    return "seta";
+  case (0x3330):
+    return "Viacom";
+  case (0x3331):
+    return "Nintendo";
+  case (0x3332):
+    return "Bandai";
+  case (0x3333):
+    return "Ocean/Acclaim";
+  case (0x3334):
+    return "Konami";
+  case (0x3335):
+    return "Hector";
+  case (0x3337):
+    return "Taito";
+  case (0x3338):
+    return "Hudson";
+  case (0x3339):
+    return "Banpresto";
+  case (0x3431):
+    return "Ubi Soft";
+  case (0x3432):
+    return "Atlus";
+  case (0x3434):
+    return "Malibu";
+  case (0x3436):
+    return "angel";
+  case (0x3437):
+    return "Bullet-Proof";
+  case (0x3439):
+    return "irem";
+  case (0x3530):
+    return "Absolute";
+  case (0x3531):
+    return "Acclaim";
+  case (0x3532):
+    return "Activision";
+  case (0x3533):
+    return "American sammy";
+  case (0x3534):
+    return "Konami";
+  case (0x3535):
+    return "Hi tech entertainment";
+  case (0x3536):
+    return "LJN";
+  case (0x3537):
+    return "Matchbox";
+  case (0x3538):
+    return "Mattel";
+  case (0x3539):
+    return "Milton Bradley";
+  case (0x3630):
+    return "Titus";
+  case (0x3631):
+    return "Virgin";
+  case (0x3634):
+    return "LucasArts";
+  case (0x3637):
+    return "Ocean";
+  case (0x3639):
+    return "Electronic Arts";
+  case (0x3730):
+    return "Infogrames";
+  case (0x3731):
+    return "Interplay";
+  case (0x3732):
+    return "Broderbund";
+  case (0x3733):
+    return "sculptured";
+  case (0x3735):
+    return "sci";
+  case (0x3738):
+    return "THQ";
+  case (0x3739):
+    return "Accolade";
+  case (0x3830):
+    return "misawa";
+  case (0x3833):
+    return "lozc";
+  case (0x3836):
+    return "Tokuma Shoten Intermedia";
+  case (0x3837):
+    return "Tsukuda Original";
+  case (0x3931):
+    return "Chunsoft";
+  case (0x3932):
+    return "Video system";
+  case (0x3933):
+    return "Ocean/Acclaim";
+  case (0x3935):
+    return "Varie";
+  case (0x3936):
+    return "Yonezawa/s’pal";
+  case (0x3937):
+    return "Kaneko";
+  case (0x3939):
+    return "Pack in soft";
+  case (0x3948):
+    return "Bottom up";
+  case (0x4134):
+   return "Konami (Yu-Gi-Oh!)";
+  default:
+    return "UNKNOWN";
+      }
+}
 static const char *LIC_CODE[0xA5] = {
+  // The old lic_code is HEX based.
     [0x00] = "None",
     [0x01] = "Nintendo R&D1",
     [0x08] = "Capcom",
@@ -115,8 +247,7 @@ const char *cart_lic_name() {
     if (ctx.header->new_lic_code <= 0xA4) {
         return LIC_CODE[ctx.header->lic_code];
     }
-
-    return "UNKNOWN";
+    return get_new_lic_code();
 }
 
 const char *cart_type_name() {
@@ -150,6 +281,9 @@ bool cart_load(char *cart) {
 
     ctx.header = (rom_header *)(ctx.rom_data + 0x100);
     ctx.header->title[15] = 0;
+
+    // new_lic_code is a two letters ASCII code c.f. (https://gbdev.io/pandocs/The_Cartridge_Header.html#01440145--new-licensee-code)
+    ctx.header->new_lic_code = (ctx.rom_data[0x144]<<8) | (ctx.rom_data[0x145]);
 
     printf("Cartridge Loaded:\n");
     printf("\t Title    : %s\n", ctx.header->title);


### PR DESCRIPTION
I was following along the code when I felt confused by the fact that one of my cartridges didn't display the correct licencee name. This is due to the fact that new licencee codes are in fact ASCII based where "01" is in fact 0x3031, while old licencee codes are hexes, where $01 means 0x01; do compare :
- https://gbdev.io/pandocs/The_Cartridge_Header.html#01440145--new-licensee-code
- https://gbdev.io/pandocs/The_Cartridge_Header.html#014b--old-licensee-code